### PR TITLE
Refine packaging by adding .npmignore files

### DIFF
--- a/apps/react-app/CHANGELOG.md
+++ b/apps/react-app/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.0.7](https://github.com/dhruv-m-patel/node-react-monorepo/compare/react-app@1.0.6...react-app@1.0.7) (2023-02-23)
+
+**Note:** Version bump only for package react-app
+
 ## [1.0.6](https://github.com/dhruv-m-patel/node-react-monorepo/compare/react-app@1.0.5...react-app@1.0.6) (2023-02-23)
 
 **Note:** Version bump only for package react-app

--- a/apps/react-app/package.json
+++ b/apps/react-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-app",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "A starter app for frontend projects with universal react, material-ui and redux support",
   "main": "build/server/index.js",
   "private": true,
@@ -23,8 +23,8 @@
     "build-storybook": "build-storybook"
   },
   "dependencies": {
-    "@dhruv-m-patel/react-components": "^1.2.4",
-    "@dhruv-m-patel/web-app": "^1.4.4",
+    "@dhruv-m-patel/react-components": "^1.2.5",
+    "@dhruv-m-patel/web-app": "^1.4.5",
     "@loadable/component": "^5.14.1",
     "@loadable/server": "^5.14.0",
     "@material-ui/core": "^4.11.2",

--- a/boilerplates/node-package/.npmignore
+++ b/boilerplates/node-package/.npmignore
@@ -1,0 +1,14 @@
+.idea
+node_modules
+coverage
+.nyc_output
+test_output.log
+tests
+jest.config.js
+.husky
+.babelrc
+src
+jest*.js
+**/*.test.js
+typings
+tsconfig.json

--- a/boilerplates/react-package/.npmignore
+++ b/boilerplates/react-package/.npmignore
@@ -1,0 +1,14 @@
+.idea
+node_modules
+coverage
+.nyc_output
+test_output.log
+tests
+jest.config.js
+.husky
+.babelrc
+src
+jest*.js
+**/*.test.js
+typings
+tsconfig.json

--- a/package.json
+++ b/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "node-react-monorepo",
+  "private": true,
   "engines": {
     "node": ">= 14.17.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,4 @@
 {
-  "name": "node-react-monorepo",
-  "private": true,
   "engines": {
     "node": ">= 14.17.0"
   },

--- a/packages/express-app/.npmignore
+++ b/packages/express-app/.npmignore
@@ -1,0 +1,14 @@
+.idea
+node_modules
+coverage
+.nyc_output
+test_output.log
+tests
+jest.config.js
+.husky
+.babelrc
+src
+jest*.js
+**/*.test.js
+typings
+tsconfig.json

--- a/packages/express-app/CHANGELOG.md
+++ b/packages/express-app/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.5](https://github.com/dhruv-m-patel/node-react-monorepo/compare/@dhruv-m-patel/express-app@1.2.4...@dhruv-m-patel/express-app@1.2.5) (2023-02-23)
+
+**Note:** Version bump only for package @dhruv-m-patel/express-app
+
 ## [1.2.4](https://github.com/dhruv-m-patel/node-react-monorepo/compare/@dhruv-m-patel/express-app@1.2.3...@dhruv-m-patel/express-app@1.2.4) (2023-02-23)
 
 **Note:** Version bump only for package @dhruv-m-patel/express-app

--- a/packages/express-app/package.json
+++ b/packages/express-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dhruv-m-patel/express-app",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "An express server to run web or api applications",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/packages/react-components/.npmignore
+++ b/packages/react-components/.npmignore
@@ -1,0 +1,14 @@
+.idea
+node_modules
+coverage
+.nyc_output
+test_output.log
+tests
+jest.config.js
+.husky
+.babelrc
+src
+jest*.js
+**/*.test.js
+typings
+tsconfig.json

--- a/packages/react-components/CHANGELOG.md
+++ b/packages/react-components/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.5](https://github.com/dhruv-m-patel/node-react-monorepo/compare/@dhruv-m-patel/react-components@1.2.4...@dhruv-m-patel/react-components@1.2.5) (2023-02-23)
+
+**Note:** Version bump only for package @dhruv-m-patel/react-components
+
 ## [1.2.4](https://github.com/dhruv-m-patel/node-react-monorepo/compare/@dhruv-m-patel/react-components@1.2.3...@dhruv-m-patel/react-components@1.2.4) (2023-02-23)
 
 **Note:** Version bump only for package @dhruv-m-patel/react-components

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dhruv-m-patel/react-components",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "A library of react components for frontend projects",
   "keywords": [
     "react",

--- a/packages/react-hooks/.npmignore
+++ b/packages/react-hooks/.npmignore
@@ -1,0 +1,14 @@
+.idea
+node_modules
+coverage
+.nyc_output
+test_output.log
+tests
+jest.config.js
+.husky
+.babelrc
+src
+jest*.js
+**/*.test.js
+typings
+tsconfig.json

--- a/packages/react-hooks/CHANGELOG.md
+++ b/packages/react-hooks/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.2.5](https://github.com/dhruv-m-patel/node-react-monorepo/compare/@dhruv-m-patel/react-hooks@1.2.4...@dhruv-m-patel/react-hooks@1.2.5) (2023-02-23)
+
+**Note:** Version bump only for package @dhruv-m-patel/react-hooks
+
 ## [1.2.4](https://github.com/dhruv-m-patel/node-react-monorepo/compare/@dhruv-m-patel/react-hooks@1.2.3...@dhruv-m-patel/react-hooks@1.2.4) (2023-02-23)
 
 **Note:** Version bump only for package @dhruv-m-patel/react-hooks

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dhruv-m-patel/react-hooks",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "A library of custom react hooks for frontend projects",
   "keywords": [
     "react",

--- a/packages/web-app/.npmignore
+++ b/packages/web-app/.npmignore
@@ -1,0 +1,14 @@
+.idea
+node_modules
+coverage
+.nyc_output
+test_output.log
+tests
+jest.config.js
+.husky
+.babelrc
+src
+jest*.js
+**/*.test.js
+typings
+tsconfig.json

--- a/packages/web-app/CHANGELOG.md
+++ b/packages/web-app/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [1.4.5](https://github.com/dhruv-m-patel/node-react-monorepo/compare/@dhruv-m-patel/web-app@1.4.4...@dhruv-m-patel/web-app@1.4.5) (2023-02-23)
+
+**Note:** Version bump only for package @dhruv-m-patel/web-app
+
 ## [1.4.4](https://github.com/dhruv-m-patel/node-react-monorepo/compare/@dhruv-m-patel/web-app@1.4.3...@dhruv-m-patel/web-app@1.4.4) (2023-02-23)
 
 **Note:** Version bump only for package @dhruv-m-patel/web-app

--- a/packages/web-app/package.json
+++ b/packages/web-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dhruv-m-patel/web-app",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "main": "build/index.js",
   "types": "build/index.d.ts",
   "license": "MIT",

--- a/readme.md
+++ b/readme.md
@@ -10,9 +10,9 @@ A monorepo for node-react projects built using lerna, managed with yarn workspac
 git clone git@github.com:dhruv-m-patel/node-react-monorepo.git
 cd node-react-monorepo
 yarn install
-yarn run bootstrap
-yarn run build
-yarn run start
+yarn bootstrap
+yarn build
+yarn start
 ```
 
 Access the react app running on http://localhost:3000
@@ -21,28 +21,19 @@ Access the backend api running on http://localhost:5000/api/message
 
 ## Packages
 
-- **packages**: Packages reusable across services or frontend.
 - **apps**: Frontend apps with styled-component, redux and configuration hydration support.
+- **boilerplates**: Boilerplate samples of packages, frontend and backend apps to serve as starter packs to expedite development
+- **packages**: Packages reusable across services or frontend.
 - **services**: Backend services.
 
-### Adding new dependencies in a specific package
+## How monorepo is used to version and publish packages?
 
-- To add a new dependency into a single package: `npx lerna add packageName --scope=packageName`
+- This monorepo embodies [Gitflow Workflow](https://www.atlassian.com/git/tutorials/comparing-workflows/gitflow-workflow) as the development process.
+  - `develop` branch is default branch. This is where all regular code development is merged. This branch is deemed unstable and is usually busy with frequent merging.
+  - `master` branch is primary branch. This is where stable releases are merged. If hotfixes are needed, branch off of master and merge it to master after ensuring stability and bring the changes down to develop.
+  - `Other` branches such as feature or regular branches are branched off of `develop` and if it stays open for longer, to ensure it does not get stale, consider merging latest from develop or rebasing it off of latest changes in develop.
+  - `release` branches are usually branched off of develop at the point it is decided that a release is needed. After ensuring branch is stable, versioning is done and then code is merged to master which will trigger publish of packages.
 
-  e.g. `npx lerna add dotenv --scope=node-service`
+- Once release branch is created, as mentioned above in last point, once you are at the point changes seem stable, versioning is done. This is done locally by running `yarn run version`. After this, push your changes up to remote using `git push --follow-tags`
 
-- To add a new dependency into multiple packages: `npx lerna add packageName --scope={packageName1, packageName2}`
-
-  e.g. `npx lerna add dotenv --scope={node-service,react-app}`
-
-- To remove a dependency, edit package.json removing the line for the dependency and then run `yarn run bootstrap`
-
-- To add a devDependency, you would have to use `npx lerna add` to add a new dependency first and then move it to devDependencies for the package and then run `yarn run bootstrap`
-
-
-## Monorepo commands
-
-- `yarn run clean`: Cleans node_modules from all packages
-- `yarn run bootstrap`: This will install dependencies from all packages hoisting and symlinking node packages as required
-- `yarn run build`: Runs build in all packages
-- `yarn run test`: Runs tests in all packages
+- Merge changes to master, this will trigger running `yarn ci:publish` in Github Actions workflow and packages should automatically be published.

--- a/services/node-service/CHANGELOG.md
+++ b/services/node-service/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [0.2.5](https://github.com/dhruv-m-patel/node-react-monorepo/compare/node-service@0.2.4...node-service@0.2.5) (2023-02-23)
+
+**Note:** Version bump only for package node-service
+
 ## [0.2.4](https://github.com/dhruv-m-patel/node-react-monorepo/compare/node-service@0.2.3...node-service@0.2.4) (2023-02-23)
 
 **Note:** Version bump only for package node-service

--- a/services/node-service/package.json
+++ b/services/node-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-service",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "main": "build/index.js",
   "private": true,
   "license": "MIT",
@@ -15,7 +15,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@dhruv-m-patel/express-app": "^1.2.4"
+    "@dhruv-m-patel/express-app": "^1.2.5"
   },
   "devDependencies": {
     "@apidevtools/swagger-cli": "^4.0.4",


### PR DESCRIPTION
- Add `.npmignore` to all packages and boilerplate samples
- This will control what gets published to npm registry when package gets pushed to npm registry
- Benefit is that publishing packages would be faster as we would be shipping lesser, precisely what is needed into npm registry.